### PR TITLE
Update statefulset.yaml

### DIFF
--- a/charts/opensearch/templates/statefulset.yaml
+++ b/charts/opensearch/templates/statefulset.yaml
@@ -392,6 +392,12 @@ spec:
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
         {{- end }}
         {{- end }}
+        startupProbe:
+          tcpSocket:
+            port: 9200
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
       {{- if .Values.masterTerminationFix }}
       {{- if eq .Values.roles.master "true" }}
       # This sidecar will prevent slow master re-election


### PR DESCRIPTION
Adding a startupProbe to fix #198 [BUG][Opensearch] helm upgrade cause all master pods killed almost simultaneously and breaks the cluster
When helm upgrades master pods, it kills all old master pods in a few seconds, leaving no time for new master pods to start up and join the cluster, eventually kills the whole cluster.
A 30-second startupProbe solve this problem